### PR TITLE
multiple commands with workspace constraints

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,18 @@
 use anyhow::Result;
 use hyprland::shared::WorkspaceType;
 use serde::Deserialize;
-use std::{fmt::Debug, fs::File, io::Read, process::Command};
+use std::{fs::File, io::Read, process::Command};
 
-#[derive(Deserialize, PartialEq, Eq, Debug)]
+#[derive(Deserialize)]
 struct Cmd {
     workspace: String,
     command: String,
     args: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+struct Cmds {
+    components: Vec<Cmd>,
 }
 
 use hyprland::{
@@ -23,11 +28,15 @@ fn main() -> Result<()> {
     let mut config = String::new();
     config_file.read_to_string(&mut config)?;
 
-    let cmd: Cmd = toml::from_str(&config)?;
+    let cmds: Cmds = toml::from_str(&config)?;
 
     event_listener.add_workspace_change_handler(move |id, state| {
         if let WorkspaceType::Regular(_ws) = &state.active_workspace {
-            if cmd.workspace == id.to_string() {
+            let mut cmds = cmds
+                .components
+                .iter()
+                .filter(|&cmd| *cmd.workspace == id.to_string());
+            if let Some(cmd) = &cmds.next() {
                 if Workspace::get_active().unwrap().windows == 0 {
                     Command::new(&cmd.command)
                         .args(cmd.args.clone().as_deref().unwrap_or_default())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,17 @@
 use anyhow::Result;
+use hyprland::shared::WorkspaceType;
 use serde::Deserialize;
-use std::{fs::File, io::Read, process::Command};
+use std::{fmt::Debug, fs::File, io::Read, process::Command};
 
-#[derive(Deserialize)]
+#[derive(Deserialize, PartialEq, Eq, Debug)]
 struct Cmd {
+    workspace: String,
     command: String,
     args: Option<Vec<String>>,
 }
 
 use hyprland::{
-    data::Workspace,
-    event_listener::EventListenerMutable as EventListener,
-    shared::{HyprDataActive, WorkspaceType},
+    data::Workspace, event_listener::EventListenerMutable as EventListener, shared::HyprDataActive,
 };
 
 fn main() -> Result<()> {
@@ -25,13 +25,15 @@ fn main() -> Result<()> {
 
     let cmd: Cmd = toml::from_str(&config)?;
 
-    event_listener.add_workspace_change_handler(move |_id, state| {
+    event_listener.add_workspace_change_handler(move |id, state| {
         if let WorkspaceType::Regular(_ws) = &state.active_workspace {
-            if Workspace::get_active().unwrap().windows == 0 {
-                Command::new(&cmd.command)
-                    .args(cmd.args.clone().as_deref().unwrap_or_default())
-                    .spawn()
-                    .unwrap();
+            if cmd.workspace == id.to_string() {
+                if Workspace::get_active().unwrap().windows == 0 {
+                    Command::new(&cmd.command)
+                        .args(cmd.args.clone().as_deref().unwrap_or_default())
+                        .spawn()
+                        .unwrap();
+                }
             }
         }
     });


### PR DESCRIPTION
new `config.toml`:

![swappy‐20230718‐105731](https://github.com/nate-sys/hypr-empty/assets/94452368/36635f19-c998-4c5e-896b-ceccc0c92cbb)
