### PR TITLE
Multiple workspaces in 1 components statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,14 @@ cargo install --git=https://github.com/nate-sys/hypr-empty
 
 ## Usage
 1) Create the file `~/.config/hypr-empty/config.toml`
-2) Specify the command you want to be run 
+2) Specify the commands you want to be run and the workspaces to run them in
 ```toml
+# Each command goes under a [[components]]
+[[components]]
+
+# List of workspaces hypr-empty should be active to
+workspaces = [ "1", "2" ]
+
 # If you're using wofi
 command = "wofi"
 args = ["-S", "drun"]
@@ -26,5 +32,15 @@ args = ["-show", "drun"]
 # arbitrary program
 command = "name_of_program"
 args = ["arg1", "arg2"]
+
+# You can specify different commands with multiple [[components]]
+# But only one workspaces/command/args per [[components]]
+
+[[components]]
+workspaces = [ "3" ]
+command = "firefox"
+
+# args is optional
+
 ```
 3) Add `hypr-empty` to your startup apps and make sure that `.cargo/bin` is in your path

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::{fs::File, io::Read, process::Command};
 
 #[derive(Deserialize)]
 struct Cmd {
-    workspace: String,
+    workspaces: Vec<String>,
     command: String,
     args: Option<Vec<String>>,
 }
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
             let mut cmds = cmds
                 .components
                 .iter()
-                .filter(|&cmd| *cmd.workspace == id.to_string());
+                .filter(|&cmd| cmd.workspaces.contains(&id.to_string()));
             if let Some(cmd) = &cmds.next() {
                 if Workspace::get_active().unwrap().windows == 0 {
                     Command::new(&cmd.command)


### PR DESCRIPTION
If the config file looks like this:
```
[[components]]
workspaces = ["5", "6", "7", "8", "9"]
command = "rofi"
args = ["-show", "drun" ]

[[components]]
workspaces = ["1", "2"]
command = "alacritty"
```
hypr-empty will spawn `alacritty` in workspaces "1" and "2", and `rofi -show drun` in workspaces "5" to "9".

The `workspace` field is no longer supported.